### PR TITLE
iSSHD requires that stat() be allowed, so don't deny it.

### DIFF
--- a/kex.c
+++ b/kex.c
@@ -662,8 +662,9 @@ kex_choose_conf(struct ssh *ssh)
 
 #ifdef NERSC_MOD
 		if ( ctos ) {
+			const char def_mac_name[] = "<implicit>";
 			char* t1buf = encode_string(newkeys->enc.name, strlen(newkeys->enc.name));
-			char* t2buf = encode_string(newkeys->mac.name, strlen(newkeys->mac.name));
+			char* t2buf = ((authlen != 0 || !newkeys->mac.name) ? (encode_string(def_mac_name, sizeof(def_mac_name)-1)) : (encode_string(newkeys->mac.name, strlen(newkeys->mac.name))));
 			char* t3buf = encode_string(newkeys->comp.name, strlen(newkeys->comp.name));
 			char* t4buf = encode_string(kex->client_version_string, strlen(kex->client_version_string));
 

--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -91,7 +91,9 @@ static const struct sock_filter preauth_insns[] = {
 	BPF_STMT(BPF_LD+BPF_W+BPF_ABS,
 		offsetof(struct seccomp_data, nr)),
 	SC_DENY(open, EACCES),
+#ifndef NERSC_MOD
 	SC_DENY(stat, EACCES),
+#endif
 	SC_ALLOW(getpid),
 	SC_ALLOW(gettimeofday),
 	SC_ALLOW(clock_gettime),


### PR DESCRIPTION
They snuck in a DENY for the stat() call while we weren't looking!  ;-)
