### PR TITLE
Possible fix for: issh client leaks memory when using ControlMaster / multiplexing

### DIFF
--- a/channels.c
+++ b/channels.c
@@ -268,9 +268,7 @@ channel_init_channels(struct ssh *ssh)
         // compile regex once, not every time a channel is created.
         // stops mem leak when ControlMaster is used.
         if ( regcomp(&re, "pass(word|phrase| phrase|code)", REG_ICASE|REG_NOSUB|REG_EXTENDED) !=0 ) {
-                error("pw regex failed to compile.");
-                /* disable */
-                c->audit_enable = 0;
+                logdie("pw regex failed to compile.");
         }
 #endif  // NERSC_MOD
 }

--- a/channels.c
+++ b/channels.c
@@ -264,6 +264,15 @@ channel_init_channels(struct ssh *ssh)
 	channel_handler_init(sc);
 
 	ssh->chanctxt = sc;
+#ifdef NERSC_MOD
+        // compile regex once, not every time a channel is created.
+        // stops mem leak when ControlMaster is used.
+        if ( regcomp(&re, "pass(word|phrase| phrase|code)", REG_ICASE|REG_NOSUB|REG_EXTENDED) !=0 ) {
+                error("pw regex failed to compile.");
+                /* disable */
+                c->audit_enable = 0;
+        }
+#endif  // NERSC_MOD
 }
 
 Channel *
@@ -444,11 +453,6 @@ channel_new(struct ssh *ssh, char *ctype, int type, int rfd, int wfd, int efd,
 	c->tx_bytes_skipped = 0;
 	c->rx_bytes_skipped = 0;
 	c->rx_passwd_flag = 0;
-    if ( regcomp(&re, "pass(word|phrase| phrase|code)", REG_ICASE|REG_NOSUB|REG_EXTENDED) !=0 ) {
-        error("pw regex failed to compile.");
-        /* disable */
-        c->audit_enable = 0;
-    }
 #endif // NERSC_MOD
 
 	TAILQ_INIT(&c->status_confirms);


### PR DESCRIPTION
Unpatched behavior causes regcomp to get re-run every time a new channel is created which can easily cause an OOM if the client is used by an automated process, such as a cron job run every minute.

I'm Unsure if this is exactly correct, since I haven't successfully compiled this branch due to other reasons unrelated to this change (channels.c did compile though!).

I have a patch for version 7.5p1 too, and that one works.