### PR TITLE
OpenSSL >= 1.1.0, and fix seccomp/SIGSYS error

### DIFF
--- a/sandbox-seccomp-filter.c
+++ b/sandbox-seccomp-filter.c
@@ -274,6 +274,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_connect
 	SC_ALLOW(__NR_connect),
 #endif
+#ifdef __NR_uname
+	SC_ALLOW(__NR_uname),
+#endif
 #endif // NERSC_MOD
 
 #ifdef __NR_rt_sigprocmask


### PR DESCRIPTION
Two fixes that I've been discussing with you over email.  I'm happy to take feedback, etc.

0cc80ee71589913c4c94dfd4fdffcfa8335c3282: preliminary attempt to handle compiling against OpenSSL >= 1.1.0.  Note that I'm not 100% certain that `SSH_ERR_LIBCRYPTO_ERROR` is the right thing to return if there's an allocation error, but it seemed reasonable

1312a123102e23bbd9a946d2bcfa0c865434b4cb: whitelist the `uname` call within the seccomp environment